### PR TITLE
feat: Implementar CU-04 Editar ETL

### DIFF
--- a/src/routes/etlRoutes.js
+++ b/src/routes/etlRoutes.js
@@ -5,10 +5,15 @@ const etlController = require('../controllers/etlController');
 const { authenticateToken, isAdmin } = require('../middleware/authMiddleware'); // O solo authenticateToken si cualquier usuario logueado puede ver los ETLs
 
 // NUEVA RUTA para CU-02: Listar todos los ETLs
-// GET /api/etls
 router.get('/', [authenticateToken, isAdmin], etlController.listarETLs); // Protegido para Admin, ajusta si es necesario
+
 //CU-03: Crear un nuevo ETL
 router.post('/', [authenticateToken, isAdmin], etlController.crearETL);
 
+// NUEVA RUTA para CU-04: Obtener un ETL específico por su ID
+router.get('/:idEtl', [authenticateToken, isAdmin], etlController.obtenerETLPorId);
+
+// NUEVA RUTA para CU-04: Actualizar un ETL específico por su ID
+router.put('/:idEtl', [authenticateToken, isAdmin], etlController.actualizarETL);
 
 module.exports = router;


### PR DESCRIPTION
- Añadido endpoint GET /api/etls/:idEtl para obtener un ETL por su ID.
- Añadido endpoint PUT /api/etls/:idEtl para actualizar un ETL existente.
- Lógica de actualización permite modificar nombre, tipo y/o descripción.
- Incluye validación para ETL no encontrado y opcional para unicidad de nombre al actualizar.
- Endpoints protegidos por rol de Administrador.