### PR TITLE
feat: Implementar CU-05 Eliminar ETL

### DIFF
--- a/src/controllers/etlController.js
+++ b/src/controllers/etlController.js
@@ -165,3 +165,26 @@ exports.actualizarETL = async (req, res) => {
   }
 };
 
+exports.eliminarETL = async (req, res) => {
+  const { idEtl } = req.params;
+
+  try {
+    // 1. Buscar el ETL por su ID
+    const etl = await ETL.findByPk(idEtl);
+
+    // 2. Si el ETL no se encuentra, devolver un error 404
+    if (!etl) {
+      return res.status(404).json({ mensaje: `ETL con ID ${idEtl} no encontrado.` });
+    }
+
+    // 3. Eliminar el ETL
+    await etl.destroy(); // Esto también eliminará en cascada los permisos asociados
+
+    // 4. Responder con un mensaje de éxito
+    return res.status(200).json({ mensaje: `ETL con ID ${idEtl} eliminado exitosamente.` });
+
+  } catch (error) {
+    console.error(`Error al eliminar ETL con ID ${idEtl}:`, error);
+    return res.status(500).json({ mensaje: 'Error interno del servidor al intentar eliminar el ETL.' });
+  }
+};

--- a/src/routes/etlRoutes.js
+++ b/src/routes/etlRoutes.js
@@ -16,4 +16,7 @@ router.get('/:idEtl', [authenticateToken, isAdmin], etlController.obtenerETLPorI
 // NUEVA RUTA para CU-04: Actualizar un ETL específico por su ID
 router.put('/:idEtl', [authenticateToken, isAdmin], etlController.actualizarETL);
 
+// NUEVA RUTA para CU-05: Eliminar un ETL específico por su ID
+router.delete('/:idEtl', [authenticateToken, isAdmin], etlController.eliminarETL);
+
 module.exports = router;


### PR DESCRIPTION
- Añadido endpoint DELETE /api/etls/:idEtl para eliminar un ETL existente.
- La lógica del controlador busca el ETL y lo destruye.
- La eliminación en cascada de los permisos asociados al ETL es manejada por la configuración 'ON DELETE CASCADE' de la base de datos.
- Se devuelve un mensaje de éxito o un error 404 si el ETL no se encuentra.
- Endpoint protegido por rol de Administrador.