### PR TITLE
feat: Implementar CU-06 Consultar Reportes del Día y Logging Global A…

### DIFF
--- a/src/controllers/reporteController.js
+++ b/src/controllers/reporteController.js
@@ -1,0 +1,71 @@
+// src/controllers/reporteController.js
+const { Reporte, ETL, Permiso, Usuario } = require('../models');
+const { Op } = require('sequelize');
+
+exports.obtenerReportesDelDia = async (req, res) => {
+  const usuarioAutenticado = req.user;
+
+  try {
+    const hoyInicio = new Date();
+    hoyInicio.setHours(0, 0, 0, 0);
+    const hoyFin = new Date();
+    hoyFin.setHours(23, 59, 59, 999);
+
+    const whereClauseReporte = {
+      FechaReporte: { // Usando PascalCase como en el modelo
+        [Op.gte]: hoyInicio,
+        [Op.lte]: hoyFin
+      }
+    };
+
+    if (usuarioAutenticado.rol === 'Consultor') {
+      const permisos = await Permiso.findAll({
+        where: { idUsuario: usuarioAutenticado.id },
+        attributes: ['idEtl']
+      });
+      if (!permisos || permisos.length === 0) {
+        return res.status(200).json([]);
+      }
+      const etlIdsPermitidos = permisos.map(p => p.idEtl);
+      whereClauseReporte.idEtl = { [Op.in]: etlIdsPermitidos };
+    } else if (usuarioAutenticado.rol !== 'Administrador') {
+      return res.status(403).json({ mensaje: 'Rol no autorizado para esta acción.' });
+    }
+
+    const reportesDelDia = await Reporte.findAll({
+      where: whereClauseReporte,
+      include: [{
+        model: ETL,
+        as: 'etl',
+        attributes: ['id', 'nombre', 'tipo']
+      }],
+      order: [
+        ['FechaReporte', 'DESC'], // <--- CORREGIDO a PascalCase
+        [{ model: ETL, as: 'etl' }, 'nombre', 'ASC']
+      ],
+      // Especifica los atributos del modelo Reporte usando sus nombres definidos en el modelo
+      attributes: ['id', 'FechaReporte', 'Status', 'idEtl'] // <--- CORREGIDO a PascalCase
+    });
+
+    const respuestaFormateada = reportesDelDia.map(r => ({
+      idReporte: r.id,
+      fechaReporte: r.FechaReporte, // <--- CORREGIDO: Accede usando el nombre del atributo del modelo
+      statusReporte: r.Status,     // <--- CORREGIDO: Accede usando el nombre del atributo del modelo
+      etl: r.etl ? {
+        idEtl: r.etl.id,
+        nombreEtl: r.etl.nombre,
+        tipoEtl: r.etl.tipo
+      } : null
+    }));
+
+    return res.status(200).json(respuestaFormateada);
+  } catch (error) {
+    console.error("Error al obtener los reportes del día:", error);
+    // Imprimir el error SQL original si existe, para más detalles en el log del servidor
+    if (error.original) {
+      console.error("Error SQL original:", error.original.sql);
+      console.error("Parámetros SQL:", error.original.parameters);
+    }
+    return res.status(500).json({ mensaje: 'Error interno del servidor al obtener los reportes.' });
+  }
+};

--- a/src/middleware/authMiddleware.js
+++ b/src/middleware/authMiddleware.js
@@ -48,7 +48,24 @@ const isAdmin = (req, res, next) => {
   }
 };
 
+const hasRequiredRole = (allowedRoles) => { // Un array de strings de roles permitidos
+  return (req, res, next) => {
+    // Se asume que authenticateToken ya se ejecutó y req.user (con req.user.rol) está disponible
+    if (!req.user || !req.user.rol) {
+      // Esto no debería pasar si authenticateToken es obligatorio antes, pero es una buena guarda
+      return res.status(403).json({ mensaje: 'Acceso denegado: Información de rol no disponible en el token.' });
+    }
+
+    if (allowedRoles.includes(req.user.rol)) {
+      next(); // El rol del usuario está en la lista de roles permitidos, continuar
+    } else {
+      return res.status(403).json({ mensaje: `Acceso denegado: Su rol ('${req.user.rol}') no tiene permiso. Requiere uno de los siguientes roles: ${allowedRoles.join(', ')}.` });
+    }
+  };
+};
+
 module.exports = {
   authenticateToken,
-  isAdmin
+  isAdmin,
+  hasRequiredRole
 };

--- a/src/middleware/loggingMiddleware.js
+++ b/src/middleware/loggingMiddleware.js
@@ -1,0 +1,75 @@
+// src/middleware/loggingMiddleware.js
+const { Log } = require('../models');
+
+const loggingMiddleware = async (req, res, next) => {
+  const startTime = process.hrtime(); // Tiempo de inicio de alta precisión
+  const fechaInicio = new Date();
+
+  // Capturar el cuerpo de la respuesta
+  // Guardamos la función original res.send
+  const originalSend = res.send;
+  let responseBody; // Variable para almacenar el cuerpo de la respuesta
+
+  // Sobrescribimos res.send para capturar su contenido
+  res.send = function (body) {
+    // Si el body no es un buffer, lo convertimos a string
+    // (esto es una simplificación, en producción puede necesitar más manejo de tipos)
+    if (body && !(body instanceof Buffer)) {
+      try {
+        // Si es un objeto, intentamos convertirlo a JSON string
+        responseBody = typeof body === 'object' ? JSON.stringify(body) : String(body);
+      } catch (e) {
+        responseBody = String(body); // Fallback a string simple
+      }
+    } else if (body instanceof Buffer) {
+      responseBody = `[Buffer data, length: ${body.length}]`; // O intenta decodificar si sabes el encoding
+    }
+    // Llamamos a la función original res.send con los argumentos originales
+    originalSend.apply(res, arguments);
+  };
+
+
+  // Cuando la respuesta haya terminado de enviarse (evento 'finish')
+  res.on('finish', async () => {
+    const fechaFin = new Date();
+    const diff = process.hrtime(startTime); // [segundos, nanosegundos]
+    const tiempoResMs = Math.round((diff[0] * 1e9 + diff[1]) / 1e6); // Convertir a milisegundos
+
+    // Limitar la longitud de la petición y respuesta para no saturar la BD
+    const MAX_LENGTH = 10000; // Por ejemplo, 10000 caracteres
+    let peticionLog = req.body ? JSON.stringify(req.body) : null;
+    if (peticionLog && peticionLog.length > MAX_LENGTH) {
+      peticionLog = peticionLog.substring(0, MAX_LENGTH) + '... [TRUNCATED]';
+    }
+
+    let respuestaLog = responseBody;
+    if (respuestaLog && respuestaLog.length > MAX_LENGTH) {
+      respuestaLog = respuestaLog.substring(0, MAX_LENGTH) + '... [TRUNCATED]';
+    }
+
+    const logData = {
+      Servicio: `${req.method} ${req.originalUrl}`,
+      Fecha_Inicio: fechaInicio,
+      Fecha_Fin: fechaFin,
+      Tiempo_Res: tiempoResMs,
+      Peticion: peticionLog,
+      Respuesta: respuestaLog, // El cuerpo capturado de la respuesta
+      Ip: req.ip || req.socket.remoteAddress,
+      // Por ahora, el usuario será 'undefined' (se guardará como NULL si la columna lo permite)
+      // Cuando tengas login, aquí pondrías req.user.nombre o req.user.id
+      Usuario: req.user ? (req.user.nombre || req.user.id) : null, // Intentar obtenerlo si ya existe req.user
+      Codigo_Res: res.statusCode
+    };
+
+    try {
+      await Log.create(logData);
+    } catch (dbError) {
+      console.error('Error al guardar el log en la base de datos:', dbError);
+      // Decide si quieres que un error de logging afecte la respuesta al cliente (probablemente no)
+    }
+  });
+
+  next(); // Continuar con el siguiente middleware o la ruta
+};
+
+module.exports = loggingMiddleware;

--- a/src/migrations/20250522180658-create-log.js
+++ b/src/migrations/20250522180658-create-log.js
@@ -1,0 +1,63 @@
+'use strict';
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('Logs', { // Sequelize pluraliza a 'Logs'
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      Servicio: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      Fecha_Inicio: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      Fecha_Fin: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      Tiempo_Res: { // En milisegundos
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      Peticion: {
+        type: Sequelize.TEXT,
+        allowNull: true
+      },
+      Respuesta: {
+        type: Sequelize.TEXT,
+        allowNull: true
+      },
+      Ip: {
+        type: Sequelize.STRING,
+        allowNull: true
+      },
+      Usuario: { // Guardará el nombre de usuario o un identificador
+        type: Sequelize.STRING,
+        allowNull: true // Permitir nulo si no hay usuario autenticado
+      },
+      Codigo_Res: { // Código de estado HTTP
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+      }
+    });
+  },
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('Logs');
+  }
+};

--- a/src/migrations/20250524051025-create-reporte.js
+++ b/src/migrations/20250524051025-create-reporte.js
@@ -1,0 +1,46 @@
+// src/migrations/<timestamp>-create-reporte.js (CORREGIDO para SET NULL)
+'use strict';
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('Reportes', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      FechaReporte: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      Status: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      idEtl: {
+        type: Sequelize.INTEGER,
+        allowNull: true, // <-- CAMBIADO A true para permitir SET NULL
+        references: {
+          model: 'ETLs',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL' // Ahora esto es válido
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+      }
+    });
+  },
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('Reportes');
+  }
+};

--- a/src/models/etl.js
+++ b/src/models/etl.js
@@ -7,8 +7,14 @@ module.exports = (sequelize, DataTypes) => {
       // Un ETL puede estar asociado a muchos registros de Permiso
       ETL.hasMany(models.Permiso, {
         foreignKey: 'idEtl',
-        as: 'permisos' // Alias opcional para la asociación
+        as: 'permisos'
       });
+      // ----> AÑADE ESTA NUEVA ASOCIACIÓN <----
+      ETL.hasMany(models.Reporte, {
+        foreignKey: 'idEtl',
+        as: 'reportes' // Usaremos este alias
+      });
+      // ------------------------------------
     }
   }
   ETL.init({

--- a/src/models/log.js
+++ b/src/models/log.js
@@ -1,0 +1,63 @@
+// src/models/log.js
+'use strict';
+const { Model } = require('sequelize');
+module.exports = (sequelize, DataTypes) => {
+  class Log extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate(models) {
+      // define association here if needed in the future
+    }
+  }
+  Log.init({
+    // Los nombres de los campos deben coincidir con los de la migración
+    // Sequelize maneja la convención de mayúsculas/minúsculas (camelCase en JS, PascalCase/snake_case en DB)
+    // pero es más seguro usar los mismos nombres que en la migración si son PascalCase.
+    // Sin embargo, Sequelize por defecto convierte camelCase del modelo a snake_case en la BD.
+    // Para que coincida con tu diagrama (PascalCase) y la migración, los especificaremos explícitamente.
+    Servicio: { // Si tu columna en la BD se llama 'Servicio'
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    Fecha_Inicio: {
+      type: DataTypes.DATE,
+      allowNull: false
+    },
+    Fecha_Fin: {
+      type: DataTypes.DATE,
+      allowNull: false
+    },
+    Tiempo_Res: {
+      type: DataTypes.INTEGER,
+      allowNull: false
+    },
+    Peticion: {
+      type: DataTypes.TEXT,
+      allowNull: true
+    },
+    Respuesta: {
+      type: DataTypes.TEXT,
+      allowNull: true
+    },
+    Ip: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    Usuario: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    Codigo_Res: {
+      type: DataTypes.INTEGER,
+      allowNull: false
+    }
+  }, {
+    sequelize,
+    modelName: 'Log',
+    tableName: 'Logs' // Asegúrate que coincida con el nombre de tabla en la migración
+  });
+  return Log;
+};

--- a/src/models/reporte.js
+++ b/src/models/reporte.js
@@ -1,0 +1,35 @@
+// src/models/reporte.js
+'use strict';
+const { Model } = require('sequelize');
+module.exports = (sequelize, DataTypes) => {
+  class Reporte extends Model {
+    static associate(models) {
+      // Un Reporte pertenece a un ETL
+      Reporte.belongsTo(models.ETL, {
+        foreignKey: 'idEtl',
+        as: 'etl', // Usaremos este alias en las consultas
+        onDelete: 'SET NULL', // Coincide con la migración
+        onUpdate: 'CASCADE'
+      });
+    }
+  }
+  Reporte.init({
+    FechaReporte: {
+      type: DataTypes.DATE,
+      allowNull: false
+    },
+    Status: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    idEtl: { // Sequelize maneja la FK, pero es bueno tenerla definida
+      type: DataTypes.INTEGER,
+      allowNull: true // Coincide con la migración para ON DELETE SET NULL
+    }
+  }, {
+    sequelize,
+    modelName: 'Reporte',
+    tableName: 'Reportes'
+  });
+  return Reporte;
+};

--- a/src/routes/reporteRoutes.js
+++ b/src/routes/reporteRoutes.js
@@ -1,0 +1,14 @@
+// src/routes/reporteRoutes.js
+const express = require('express');
+const router = express.Router();
+const reporteController = require('../controllers/reporteController');
+const { authenticateToken, hasRequiredRole } = require('../middleware/authMiddleware');
+
+// GET /api/reportes/hoy
+router.get(
+  '/hoy',
+  [authenticateToken, hasRequiredRole(['Administrador', 'Consultor'])],
+  reporteController.obtenerReportesDelDia
+);
+
+module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -6,19 +6,24 @@ require('dotenv').config();
 const express = require('express');
 const { sequelize } = require('./models');
 
+const loggingMiddleware = require('./middleware/loggingMiddleware');
+
 // Importar las rutas
 const usuarioRoutes = require('./routes/usuarioRoutes'); // <--- AÑADE ESTA LÍNEA
 const etlRoutes = require('./routes/etlRoutes'); // <--- AÑADE ESTA LÍNEA
+const reporteRoutes = require('./routes/reporteRoutes');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+app.use(loggingMiddleware);
 
 // Montar las rutas de la API
 app.use('/api/usuarios', usuarioRoutes); // <--- AÑADE ESTA LÍNEA: Todas las rutas en usuarioRoutes estarán prefijadas con /api/usuarios
 app.use('/api/etls', etlRoutes);
+app.use('/api/reportes', reporteRoutes);
 
 app.get('/', (req, res) => {
   res.send('¡API de ETLs funcionando correctamente!');


### PR DESCRIPTION
…PI" \

-m "Implementa el Caso de Uso CU-06 para consultar reportes de ETL del día actual y añade un sistema de logging global para las solicitudes API.

Funcionalidad CU-06 (Consultar Reportes del Día):
- Añadido endpoint GET /api/reportes/hoy para obtener reportes de ETLs generados en el día actual.
- Creado modelo Reporte y su migración, incluyendo la clave foránea 'idEtl' y la asociación con el modelo ETL.
- Middleware de autorización 'authMiddleware.js' actualizado con la función 'hasRequiredRole' para permitir el acceso a los roles 'Administrador' y 'Consultor'.
- La lógica del controlador filtra los reportes por fecha (día actual).
- Para el rol 'Consultor', los reportes se filtran adicionalmente para mostrar solo aquellos de los ETLs a los que tiene permiso.
- Para el rol 'Administrador', se muestran todos los reportes del día.
- La respuesta incluye detalles del reporte y la información básica del ETL asociado.

Sistema de Logging Global:
- Creado modelo Log y migración para la tabla 'Logs' según el diagrama de base de datos.
- Desarrollado middleware 'loggingMiddleware' para capturar y registrar detalles de las solicitudes y respuestas HTTP.
- El log incluye: Servicio (endpoint y método), Fecha_Inicio, Fecha_Fin, Tiempo_Res (ms), Petición (cuerpo), Respuesta (cuerpo), IP del cliente, Usuario (si está autenticado), y Código_Res (estado HTTP).
- Implementado truncado para los cuerpos de Petición y Respuesta para evitar sobrecargar la base de datos.
- Middleware integrado globalmente en la aplicación Express para registrar la actividad de todas las rutas API.
- El campo Usuario en el log utiliza 'req.user.nombre' o 'req.user.id' si está disponible, de lo contrario 'null'.