### PR TITLE
feat: Implementar CU-07 Consultar Reportes por Fecha Específica

### DIFF
--- a/src/controllers/reporteController.js
+++ b/src/controllers/reporteController.js
@@ -69,3 +69,96 @@ exports.obtenerReportesDelDia = async (req, res) => {
     return res.status(500).json({ mensaje: 'Error interno del servidor al obtener los reportes.' });
   }
 };
+
+exports.obtenerReportesPorFecha = async (req, res) => {
+  const { fecha } = req.query; // Obtener la fecha del query parameter
+  const usuarioAutenticado = req.user; // { id, nombre, rol }
+
+  // 1. Validar el parámetro 'fecha'
+  if (!fecha) {
+    return res.status(400).json({ mensaje: 'El parámetro "fecha" (YYYY-MM-DD) es requerido.' });
+  }
+
+  // Validar formato YYYY-MM-DD (expresión regular simple)
+  const regexFecha = /^\d{4}-\d{2}-\d{2}$/;
+  if (!regexFecha.test(fecha)) {
+    return res.status(400).json({ mensaje: 'El formato de "fecha" debe ser YYYY-MM-DD.' });
+  }
+
+  // 2. Convertir la fecha string a objeto Date y calcular rango del día
+  // ¡Importante! Esto usa la zona horaria del servidor.
+  // new Date('YYYY-MM-DD') se interpreta como YYYY-MM-DD a las 00:00:00 en UTC.
+  // Para interpretar como 00:00:00 en la zona horaria local del servidor, podemos añadir T00:00:00
+  const fechaConsultada = new Date(fecha + 'T00:00:00'); 
+  if (isNaN(fechaConsultada.getTime())) {
+      return res.status(400).json({ mensaje: 'La fecha proporcionada no es válida.' });
+  }
+
+  const inicioDelDia = new Date(fechaConsultada);
+  inicioDelDia.setHours(0, 0, 0, 0);
+
+  const finDelDia = new Date(fechaConsultada);
+  finDelDia.setHours(23, 59, 59, 999);
+
+  try {
+    // 3. Construir la cláusula 'where' base para los reportes
+    const whereClauseReporte = {
+      FechaReporte: { // Asegúrate que coincida con el nombre del atributo en tu modelo Reporte
+        [Op.gte]: inicioDelDia,
+        [Op.lte]: finDelDia
+      }
+    };
+
+    // 4. Si el usuario es Consultor, filtrar por ETLs permitidos
+    if (usuarioAutenticado.rol === 'Consultor') {
+      const permisos = await Permiso.findAll({
+        where: { idUsuario: usuarioAutenticado.id },
+        attributes: ['idEtl']
+      });
+
+      if (!permisos || permisos.length === 0) {
+        return res.status(200).json([]); // Consultor sin permisos, devuelve array vacío
+      }
+      const etlIdsPermitidos = permisos.map(p => p.idEtl);
+      whereClauseReporte.idEtl = { [Op.in]: etlIdsPermitidos };
+    } else if (usuarioAutenticado.rol !== 'Administrador') {
+      return res.status(403).json({ mensaje: 'Rol no autorizado para esta acción.' });
+    }
+    // Los Administradores no tienen el filtro de idEtl adicional.
+
+    // 5. Obtener los reportes para la fecha especificada
+    const reportesDelDiaEspecificado = await Reporte.findAll({
+      where: whereClauseReporte,
+      include: [{
+        model: ETL,
+        as: 'etl', // Alias de la asociación Reporte.belongsTo(ETL)
+        attributes: ['id', 'nombre', 'tipo']
+      }],
+      order: [
+        ['FechaReporte', 'DESC'], // Los más recientes de ese día primero
+        [{ model: ETL, as: 'etl' }, 'nombre', 'ASC']
+      ],
+      attributes: ['id', 'FechaReporte', 'Status', 'idEtl'] // Usar PascalCase como en el modelo
+    });
+
+    // 6. Formatear la respuesta (igual que en CU-06)
+    const respuestaFormateada = reportesDelDiaEspecificado.map(r => ({
+      idReporte: r.id,
+      fechaReporte: r.FechaReporte, // Usar PascalCase
+      statusReporte: r.Status,     // Usar PascalCase
+      etl: r.etl ? {
+        idEtl: r.etl.id,
+        nombreEtl: r.etl.nombre,
+        tipoEtl: r.etl.tipo
+      } : null
+    }));
+
+    // Si no se encuentran reportes, se devuelve un array vacío (200 OK).
+    // El frontend se encargará de mostrar el mensaje "No existe ningún reporte..." (EX-01)
+    return res.status(200).json(respuestaFormateada);
+
+  } catch (error) {
+    console.error(`Error al obtener los reportes para la fecha ${fecha}:`, error);
+    return res.status(500).json({ mensaje: 'Error interno del servidor al obtener los reportes.' });
+  }
+};

--- a/src/routes/reporteRoutes.js
+++ b/src/routes/reporteRoutes.js
@@ -11,4 +11,10 @@ router.get(
   reporteController.obtenerReportesDelDia
 );
 
+router.get(
+  '/por-fecha',
+  [authenticateToken, hasRequiredRole(['Administrador', 'Consultor'])],
+  reporteController.obtenerReportesPorFecha
+);
+
 module.exports = router;

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -532,3 +532,57 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /reportes/por-fecha: # Nueva definición para CU-07
+    get:
+      tags:
+        - Reportes
+      summary: Consulta reportes por fecha específica (CU-07)
+      description: |
+        Obtiene todos los registros de la tabla Reporte cuya fechaReporte corresponda a la fecha especificada en el parámetro de consulta.
+        - El formato de fecha es YYYY-MM-DD.
+        - Administradores: Ven todos los reportes de la fecha especificada.
+        - Consultores: Ven los reportes de la fecha especificada, pero solo de los ETLs a los que tienen permiso.
+      security:
+        - bearerAuth: [] # Requiere token de Administrador o Consultor
+      parameters:
+        - name: fecha # Nombre del parámetro de consulta
+          in: query # Indica que es un query parameter (ej. /por-fecha?fecha=YYYY-MM-DD)
+          required: true
+          description: "Fecha para la cual se consultarán los reportes, en formato YYYY-MM-DD."
+          schema:
+            type: string
+            format: date # Esto ayuda a Swagger UI a mostrar un selector de fecha
+            example: "2025-05-20" 
+      responses:
+        '200':
+          description: Una lista de reportes para la fecha especificada. El array estará vacío si no se encuentran reportes.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ReporteDelDia' # Usamos el mismo schema que para /reportes/hoy
+        '400':
+          description: Error en la solicitud (ej. parámetro 'fecha' faltante o en formato incorrecto).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: No autorizado (token no válido o no provisto).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Prohibido (el rol del usuario no tiene permisos).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Error interno del servidor.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'


### PR DESCRIPTION
- Añadido endpoint GET /api/reportes/por-fecha para obtener reportes de ETLs de una fecha específica.
- El endpoint requiere un parámetro de consulta 'fecha' en formato YYYY-MM-DD.
- Se implementó la validación para el formato y la presencia del parámetro 'fecha'.
- La lógica del controlador filtra los reportes según el rango de la fecha proporcionada.
- Administradores ven todos los reportes de la fecha; Consultores ven reportes de ETLs permitidos para esa fecha.
- El endpoint está protegido y requiere rol de Administrador o Consultor.
- Actualizada la documentación en swagger.yaml para incluir este nuevo endpoint y sus detalles.