### PR TITLE
feat(Notificaciones): Implementar CU-08 Recibir Notificación de Fallo…

### DIFF
--- a/src/middleware/loggingMiddleware.js
+++ b/src/middleware/loggingMiddleware.js
@@ -2,6 +2,10 @@
 const { Log } = require('../models');
 
 const loggingMiddleware = async (req, res, next) => {
+  if (req.originalUrl.startsWith('/api-docs')) {
+    return next(); // Si es una ruta de Swagger UI, no la logueamos y pasamos al siguiente middleware.
+  }
+
   const startTime = process.hrtime(); // Tiempo de inicio de alta precisión
   const fechaInicio = new Date();
 

--- a/src/migrations/20250524225548-create-usuario-reporte-acuse.js
+++ b/src/migrations/20250524225548-create-usuario-reporte-acuse.js
@@ -1,0 +1,61 @@
+// src/migrations/<timestamp>-create-usuario-reporte-acuse.js
+'use strict';
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('UsuarioReporteAcuses', { // Sequelize pluraliza
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      idUsuario: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'Usuarios', // Nombre de tu tabla de Usuarios
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE' // Si se borra el usuario, se borran sus acuses
+      },
+      idReporte: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'Reportes', // Nombre de tu tabla de Reportes
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE' // Si se borra el reporte, se borra el acuse (importante)
+      },
+      fechaAcuse: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.NOW
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+      }
+    });
+
+    // Añadir una restricción UNIQUE compuesta para evitar duplicados
+    await queryInterface.addConstraint('UsuarioReporteAcuses', {
+      fields: ['idUsuario', 'idReporte'],
+      type: 'unique',
+      name: 'unique_usuario_reporte_acuse'
+    });
+  },
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeConstraint('UsuarioReporteAcuses', 'unique_usuario_reporte_acuse');
+    await queryInterface.dropTable('UsuarioReporteAcuses');
+  }
+};

--- a/src/models/reporte.js
+++ b/src/models/reporte.js
@@ -23,6 +23,10 @@ module.exports = (sequelize, DataTypes) => {
         foreignKey: 'idReporte',
         as: 'detalleAlerta'
       });
+      Reporte.hasMany(models.UsuarioReporteAcuse, {
+        foreignKey: 'idReporte',
+        as: 'usuariosQueAcusaron'
+      });
     }
   }
   Reporte.init({

--- a/src/models/usuario.js
+++ b/src/models/usuario.js
@@ -9,6 +9,10 @@ module.exports = (sequelize, DataTypes) => {
         foreignKey: 'idUsuario',
         as: 'permisos' // Alias opcional
       });
+      Usuario.hasMany(models.UsuarioReporteAcuse, {
+        foreignKey: 'idUsuario',
+        as: 'acusesDeReporte'
+      });
     }
   }
   Usuario.init({
@@ -21,7 +25,7 @@ module.exports = (sequelize, DataTypes) => {
     },
     rol: {
       type: DataTypes.STRING,
-      allowNull: true, 
+      allowNull: true,
       defaultValue: 'consultor'
     }
   }, {

--- a/src/models/usuarioreporteacuse.js
+++ b/src/models/usuarioreporteacuse.js
@@ -1,0 +1,46 @@
+// src/models/usuarioreporteacuse.js
+'use strict';
+const { Model } = require('sequelize');
+module.exports = (sequelize, DataTypes) => {
+  class UsuarioReporteAcuse extends Model {
+    static associate(models) {
+      UsuarioReporteAcuse.belongsTo(models.Usuario, {
+        foreignKey: 'idUsuario',
+        as: 'usuario'
+      });
+      UsuarioReporteAcuse.belongsTo(models.Reporte, {
+        foreignKey: 'idReporte',
+        as: 'reporte'
+      });
+    }
+  }
+  UsuarioReporteAcuse.init({
+    idUsuario: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      // references: { model: 'Usuarios', key: 'id' } // Ya definido por la asociación
+    },
+    idReporte: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      // references: { model: 'Reportes', key: 'id' } // Ya definido por la asociación
+    },
+    fechaAcuse: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW
+    }
+  }, {
+    sequelize,
+    modelName: 'UsuarioReporteAcuse',
+    tableName: 'UsuarioReporteAcuses',
+    indexes: [ // Definir el índice unique también en el modelo
+      {
+        unique: true,
+        fields: ['idUsuario', 'idReporte'],
+        name: 'unique_usuario_reporte_acuse_model'
+      }
+    ]
+  });
+  return UsuarioReporteAcuse;
+};

--- a/src/routes/reporteRoutes.js
+++ b/src/routes/reporteRoutes.js
@@ -35,4 +35,16 @@ router.post(
   reporteController.registrarReporteAlerta
 );
 
+router.get(
+  '/criticos-no-acusados',
+  [authenticateToken, hasRequiredRole(['Administrador', 'Consultor'])],
+  reporteController.obtenerReportesCriticosNoAcusados
+);
+
+router.post(
+  '/:idReporte/acusar', // :idReporte será un parámetro de ruta
+  [authenticateToken, hasRequiredRole(['Administrador', 'Consultor'])],
+  reporteController.acusarReciboReporteCritico
+);
+
 module.exports = router;


### PR DESCRIPTION
… Crítico

- Creado modelo UsuarioReporteAcuse y su migración para registrar qué usuarios han acusado recibo de reportes críticos.
- Definidas asociaciones entre UsuarioReporteAcuse, Usuario y Reporte.
- Añadido endpoint GET /api/reportes/criticos-no-acusados:
    - Devuelve reportes con Status='Fallido Crítico' que el usuario autenticado no ha acusado.
    - Filtra por permisos de ETL para el rol 'Consultor'; 'Administrador' ve todos los aplicables.
- Añadido endpoint POST /api/reportes/:idReporte/acusar:
    - Permite al usuario autenticado marcar un reporte crítico como acusado.
    - Utiliza findOrCreate para manejar múltiples acuses de forma idempotente.
- Ambos endpoints requieren autenticación y rol de 'Administrador' o 'Consultor'.
- Lógica implementada para que las notificaciones de fallos críticos no sean repetitivas para un mismo usuario una vez acusadas.