### PR TITLE
feat(Reportes): Implementar CU-09 Ver Detalle de Reporte

### DIFF
--- a/src/routes/reporteRoutes.js
+++ b/src/routes/reporteRoutes.js
@@ -47,4 +47,10 @@ router.post(
   reporteController.acusarReciboReporteCritico
 );
 
+router.get(
+  '/:idReporte', // Usaremos esta ruta más corta y estándar
+  [authenticateToken, hasRequiredRole(['Administrador', 'Consultor'])],
+  reporteController.obtenerDetalleReporte
+);
+
 module.exports = router;


### PR DESCRIPTION
- Añadido endpoint GET /api/reportes/:idReporte para obtener el detalle completo de un reporte específico.
- La lógica del controlador recupera el reporte principal, el ETL asociado y el detalle específico (ETLProcesamiento, ETLArchivo o ETLAlerta).
- Implementada verificación de permisos para el rol 'Consultor': solo pueden ver detalles de reportes de ETLs a los que tienen acceso.
- Administradores pueden ver detalles de cualquier reporte.
- El endpoint está protegido y requiere rol de 'Administrador' o 'Consultor'.